### PR TITLE
docs: update github page + some readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 <h1 align="center">
-  <img src="https://user-images.githubusercontent.com/62793491/208452652-71416c5c-8261-4501-a002-afc9e2cf0a0b.png" width="224px"/><br/>
+  <img src="https://user-images.githubusercontent.com/62793491/208452652-71416c5c-8261-4501-a002-afc9e2cf0a0b.png" width="224px"/>
+
   <b>Livl Shell</b>
 </h1>  
 <h4 align="center">
   An Intermediate Reimplementation of the Bash Shell in C
 </h4>
 
-# Table of Contents
+## Table of Contents
+
 - [📦 Prerequisites](#-prerequisites)
 - [🚀 Quick start](#-quick-start)
 - [📚 Makefile Guide](#-makefile-guide)
@@ -30,16 +32,18 @@
     - [2. Static Pipeline](#2-static-pipeline)
 - [🧍🏽Project team](#-project-team)
 
-# 📦 Prerequisites
+## 📦 Prerequisites
 
-This project is developed in C language, so you need to have a C compiler installed on your machine. It would be better to run it on a Linux distribution, but it is possible to run it on Windows with the WSL (Windows Subsystem for Linux).
+This project is developed in C language, so you need to have a C compiler installed on your machine to build it.
+It would be better to run it on a Linux distribution, but it has also been tested on macOS.
+It is possible to run it on Windows with the WSL (Windows Subsystem for Linux).
 
-- `gcc` : `sudo apt install gcc`
-- `make`: `sudo apt install make`
+- gcc : `sudo apt install gcc`
+- make: `sudo apt install make`
 
 > To install the WSL on Windows, follow this [tutorial](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 
-# 🚀 Quick start
+## 🚀 Quick start
 
 Follow these steps to quickly get started:
 
@@ -53,7 +57,7 @@ Follow these steps to quickly get started:
 
 > 💡 **Tip**: The command `make run` will compile and immediately run the executable. It is equivalent to running `make && ./bin/livl-shell`.
 
-# 📚 Makefile Guide
+## 📚 Makefile Guide
 
 The project uses a Makefile for managing build tasks. Here are some of the available targets:
 
@@ -69,7 +73,7 @@ The project uses a Makefile for managing build tasks. Here are some of the avail
 
 You can use the `make help` command to display a brief description of each target.
 
-# 📁 Project structure
+## 📁 Project structure
 
 The project is structured as follows:
 
@@ -95,84 +99,83 @@ livl-shell/
 └── Makefile # Makefile
 ```
 
-# 📝 List of Insane livl-bash Commands
+## 📝 List of Insane livl-bash Commands
 
 > 💡 The livl-shell is limited to run a maximum of 3 commands in a row.
 
-## Basic Commands
+### Basic Commands
 
 - `ls`: Lists the files in the current directory.
 - `cd`: Changes the current directory.
 - `pwd`: Prints the current directory.
 - `echo`: Displays a line of text.
 
-## Input/Output Redirection
+### Input/Output Redirection
 
 - `ls -l > output.txt`: Redirects the output of a command to a file.
 - `pwd >> output.txt`: Appends the output of a command to a file.
 - `wc -l < output.txt`: Counts the number of lines in the file.
 
-## Pipelines
+### Pipelines
 
 - `ls -l | grep '.txt'`: Redirects the output of a command to another command. You can use single, double, or no quotes.
 
-## Command Sequencing
+### Command Sequencing
 
 - `sleep 4 && echo "Second command executed"`: Executes a command after another one.
 - `false && echo "This won't be executed"`: Executes a command after another one only if the first one succeeded.
 - `false || echo "This will be executed"`: Executes a command after another one only if the first one failed.
 - `echo "Command 1"; sleep 3; echo "Command 2"; ls -l`: Executes multiple commands regardless of the success of the previous ones.
 
-## Batch Mode
+### Batch Mode
 
 > ⚠️ The command should be enclosed in quotes to ensure it is passed as a single argument
 
 - `./livl-shell -c "ls -l|grep txt && echo heyyy"`: Executes a list of commands from the command line.
 - `./livl-shell --command "echo livl"`: Executes a list of commands from the command line.
 
-## Background Execution
+### Background Execution
 
 - `sleep 3 & echo hey`: Executes a command in the background (the shell will not wait for the command to finish) and it will show you the job id of the background process (ex: `[1] 1234`).
-    - `pwd`: Running this command will display the job id of the background process terminated (ex: `[1] done sleep 3`).
+- `pwd`: Running this command will display the job id of the background process terminated (ex: `[1] done sleep 3`).
 
-
-# 📖 Use the livl-bash `man` command 
+## 📖 Use the livl-bash `man` command
 
 > To edit the man you can download a TROFF Syntax Highlighter for Visual Studio Code.
 
 - The `man livl-shell` manual is located in the [`livl-shell.1`](livl-shell.1) file
 - To view the manual, run : `man ./livl-shell.1`
 
-# 📜 Doxygen documentation
+## 📜 Doxygen documentation
 
 > ❓ Doxygen is a documentation generator, a tool for writing software reference documentation.
 
-## 📦 Prerequisites of Doxygen
+### 📦 Prerequisites of Doxygen
 
-- `Download doxygen` : `sudo apt install doxygen`
+- Download doxygen : `sudo apt install doxygen`
 
-## 🚀 Generate the Doxygen documentation
+### 🚀 Generate the Doxygen documentation
 
 - Run `make doc` to generate the documentation
 - To view the documentation, open the [`index.html`](/doc/html/index.html) file in the `doc/html/` folder.
 
-# 🧪 GCOV test coverage
+## 🧪 GCOV test coverage
 
 > ❓ GCOV is a test coverage program. It helps you determine how much of your source code is being tested by your test suite. It is a useful tool for finding untested code.
 
-## 📦 Prerequisites of gcov
+### 📦 Prerequisites of gcov
 
-- `Download gcov` : `sudo apt install gcov`
-- `Download lcov` : `sudo apt install lcov`
+- Download gcov : `sudo apt install gcov`
+- Download lcov : `sudo apt install lcov`
 
-## 🚀 Generate the coverage report
+### 🚀 Generate the coverage report
 
 - Run `make gcov` to generate the coverage report
 - To exit the coverage report, press `exit` two times (one for the shell and one for the coverage report)
 - To view the coverage report, open the [`index.html`](/gcov/report/index.html) file in the `gcov/report/` folder or run `gcovr -r .`
 - Run `make clean-gcov` to clean the `gcov` folder
 
-# 🛠️ Pipeline
+## 🛠️ Pipeline
 
 Our pipelines are configured to be triggered on each `push` and `pull request` event on the `master` branch. We have two main pipelines:
 
@@ -185,7 +188,7 @@ The `c-make` pipeline compiles the project using the `make` command.
 The `static` pipeline hosts the static website on GitHub Pages at the root of the repository. This allows access to the Doxygen documentation and the Coverage report at the following address: https://livl-corporation.github.io/livl-shell/
 
 
-# 🧍🏽Project team
+## 🧍🏽Project team
 
 The Livl team is composed of two members from the CNAM of Strasbourg:
 

--- a/include/history_command.h
+++ b/include/history_command.h
@@ -2,7 +2,7 @@
  * @file history_command.h
  * @author Julien & Franck
  * @date 24 Dec 2023
- * @brief File containing the history command functions to manage the history of commands entered by the user (saving, loading, etc.) to a file.
+ * @brief File containing the functions to manage (load & save, etc.) the history of commands entered by the user to a file.
  */
 #ifndef HISTORY_COMMAND_H
 #define HISTORY_COMMAND_H
@@ -14,50 +14,50 @@
 
 /**
  * @brief The max size of the history
-*/
+ */
 #define MAX_HISTORY_SIZE 1000
 
 /**
  * @brief The history file name
-*/
+ */
 #define HISTORY_FILE "history.txt"
 
 /**
  * @brief The global history of commands entered by the user
-*/
+ */
 extern CommandHistory global_command_history;
 
 /**
  * @brief Initialize the global command history
-*/
+ */
 void initialize_command_history();
 
 /**
  * @brief Add a command to the global command history
  * @param command The command to be added
-*/
+ */
 void add_to_command_history(const char *command);
 
 /**
  * @brief Get the previous command from the global command history
  * @return The previous command
-*/
+ */
 const char *get_previous_command();
 
 /**
  * @brief Get the next command from the global command history
  * @return The next command
-*/
+ */
 const char *get_next_command();
 
 /**
  * @brief Save the command history to the history file
-*/
+ */
 void save_command_history_to_file();
 
 /**
  * @brief Load the command history from the history file
-*/
+ */
 void load_command_history_from_file();
 
-#endif //HISTORY_COMMAND_H
+#endif // HISTORY_COMMAND_H

--- a/include/scheduler.h
+++ b/include/scheduler.h
@@ -22,30 +22,30 @@
 
 /**
  * @brief The child process id (pid)
-*/
+ */
 #define CHILD_PROCESS 0
 
 /**
- * @brief Executes a command
+ * @brief Executes an external command
  * @param command The command to execute
  * @param run_in_background 0 for false, 1 for true
  * @return The status of the execution
-*/
+ */
 int execute_external_command(const Command *command, int run_in_background);
 
 /**
- * @brief Executes a command
+ * @brief Executes a command internal to the shell
  * @param command The command to execute
  * @param run_in_background 0 for false, 1 for true
  * @return The status of the execution
-*/
+ */
 int execute_command(const Command *command, int run_in_background);
 
 /**
  * @brief Executes a sequence of commands with operators
  * @param sequence The sequence of commands to execute
  * @return The status of the execution
-*/
+ */
 int execute_command_sequence(const CommandSequence *sequence);
 
-#endif //SCHEDULER_H
+#endif // SCHEDULER_H

--- a/include/typedef.h
+++ b/include/typedef.h
@@ -12,85 +12,87 @@
 
 /**
  * Enum that represents the type of an operator
-*/
-typedef enum {
-    AND,
-    OR,
-    REDIRECTION_APPEND_OUTPUT,
-    REDIRECTION_APPEND_INPUT,
-    SEMICOLON,
-    PIPE,
-    BACKGROUND,
-    REDIRECTION_OUTPUT,
-    REDIRECTION_INPUT,
-    UNKNOWN,
+ */
+typedef enum
+{
+    AND,                       // &&
+    OR,                        // ||
+    REDIRECTION_APPEND_OUTPUT, // >>
+    REDIRECTION_APPEND_INPUT,  // <<
+    SEMICOLON,                 // ;
+    PIPE,                      // |
+    BACKGROUND,                // &
+    REDIRECTION_OUTPUT,        // >
+    REDIRECTION_INPUT,         // <
+    UNKNOWN,                   // Unknown operator
 } OperatorType;
 
 /**
  * @struct BackgroundProcess
  * @brief Struct that represents a background process.
- * 
+ *
  * @var BackgroundProcess::pid
  * Process ID.
- * 
+ *
  * @var BackgroundProcess::job_number
  * Job number.
- * 
+ *
  * @var BackgroundProcess::command
  * Command and its arguments.
  */
-typedef struct {
+typedef struct
+{
     pid_t pid;
     int job_number;
     char *command;
 } BackgroundProcess;
 
-
 /**
  * @struct Redirection
  * @brief Struct that represents a redirection.
- * 
+ *
  * @var Redirection::input_file
  * Input file.
- * 
+ *
  * @var Redirection::output_file
  * Output file.
- * 
+ *
  * @var Redirection::append_input
  * Append input.
- * 
+ *
  * @var Redirection::append_output
  * Append output.
-*/
-typedef struct {
+ */
+typedef struct
+{
     char *input_file;
     char *output_file;
     int append_input;
     int append_output;
 } Redirection;
 
-
 /**
  * @struct Command
  * @brief Struct that represents a command.
- * 
+ *
  * @var Command::command
  * Command.
- * 
+ *
  * @var Command::arguments
  * Arguments.
- * 
+ *
  * @var Command::complete_command
  * Complete command.
- * 
+ *
  * @var Command::num_arguments
  * Number of arguments.
- * 
+ *
  * @var Command::redirection
  * Redirection.
-*/
-typedef struct {
-    char *command;   
+ */
+typedef struct
+{
+    char *command;
     char **arguments;
     char **complete_command;
     int num_arguments;
@@ -100,39 +102,41 @@ typedef struct {
 /**
  * @struct CommandSequence
  * @brief Struct that represents a command sequence.
- * 
+ *
  * @var CommandSequence::commands
  * Array of commands.
- * 
+ *
  * @var CommandSequence::operators
  * Array of operators.
- * 
+ *
  * @var CommandSequence::num_commands
  * Number of commands.
-*/
-typedef struct {
-    Command *commands;      // Array of commands
-    char **operators;       // Array of operators
-    size_t num_commands;    // Number of commands
+ */
+typedef struct
+{
+    Command *commands;   // Array of commands
+    char **operators;    // Array of operators
+    size_t num_commands; // Number of commands
 } CommandSequence;
 
 /**
  * @struct CommandHistory
  * @brief Struct that represents the command history.
- * 
+ *
  * @var CommandHistory::history
  * Array of commands.
- * 
+ *
  * @var CommandHistory::history_count
  * Number of commands in the history.
- * 
+ *
  * @var CommandHistory::current_index
  * Current index in the history.
  */
-typedef struct {
+typedef struct
+{
     char history[1000][1000];
     int history_count;
     int current_index;
 } CommandHistory;
 
-#endif //TYPEDEF_H
+#endif // TYPEDEF_H

--- a/index.html
+++ b/index.html
@@ -1,88 +1,65 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="UTF-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <title>Livl Shell - Documentation</title>
-        <link rel="shortcut icon" type="image/x-icon" href="https://raw.githubusercontent.com/Livl-Corporation/livl-shell/master/img/livl_logo.ico?">
-        <style>
-            @import url('https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css');
-            @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
-            body {
-                font-family: 'Inter', sans-serif;
-            }
-            code {
-                font-size: small;
-                background-color: #f7fafc;
-                color: #374151;
-                padding: 0.25rem;
-                border-radius: 0.25rem;
-            }
-        </style>
-    </head>
-    <body class="p-10">
-        <div class="flex flex-col items-center">
-            <img src="https://user-images.githubusercontent.com/62793491/208452652-71416c5c-8261-4501-a002-afc9e2cf0a0b.png" width="224px"/>
-            <h1 class="text-center text-4xl font-bold my-4"><br/>
-                Livl Shell - Documentation
-            </h1> 
-        </div>
-        
-        <p class="text-center text-lg opacity-70">Livl Shell is an intermediate reimplementation of the bash shell in C language.</p> 
 
-        <div class="mt-10">
-            <h2 class="text-3xl font-bold my-5">⛓️ Links of the different documentations</h2>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Livl Shell - Documentation</title>
+    <link rel="shortcut icon" type="image/x-icon"
+        href="https://raw.githubusercontent.com/Livl-Corporation/livl-shell/master/img/livl_logo.ico?">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style type="text/tailwindcss">
+        @layer components {
+          code {
+            @apply bg-gray-100 text-gray-800 p-1 rounded text-sm font-mono;
+          }
 
-            <ul class="list-disc list-inside space-y-2">
-                <li class="p-3 rounded-md bg-blue-100 hover:bg-blue-200 transition-colors duration-200"> 
-                    <a class="text-blue-700 font-semibold hover:underline" href="https://livl-corporation.github.io/livl-shell/doc/html/">
-                        <span class="inline-block p-1 px-2 mr-2 rounded bg-blue-500 text-white text-xs">DOXYGEN</span>
-                        Visit the generated Doxygen documentation.
-                    </a>
-                </li>
-                <li class="p-3 rounded-md bg-green-100 hover:bg-green-200 transition-colors duration-200">
-                    <a class="text-green-700 font-semibold hover:underline" href="https://livl-corporation.github.io/livl-shell/gcov/report/">
-                        <span class="inline-block p-1 px-2 mr-2 rounded bg-green-500 text-white text-xs">GCOV</span>
-                        Visit the generated GCOV coverage report.
-                    </a>
-                </li>
-            </ul>
-        </div>
-        
-        <div class="mt-8 p-4 rounded-md bg-blue-100">
-            <h2 class="text-3xl font-bold my-4">🆕 Generate the documentation</h2>
-        
-            <div class="my-4 p-4 rounded-md bg-white shadow">
-                <h3 class="text-xl font-bold my-4">Generate DOXYGEN documentation</h3>
-                <h3 class="text-lg font-bold my-2">📦 Prerequisites of gcov</h3>
-                <ul class="list-disc list-inside">
-                    <li><code class="text-sm bg-gray-100 text-gray-800 p-1 rounded">doxygen</code>: <pre class="inline bg-gray-100 rounded"><code>sudo apt install doxygen</code></pre></li>
-                </ul>
-                
-                <h3 class="text-lg font-bold my-2">🚀 How to run it</h3>
-                <ul class="list-disc list-inside">
-                    <li>Run <code class="text-sm bg-gray-100 text-gray-800 p-1 rounded">make doc</code> to generate the documentation</li>
-                    <li>To view the documentation, open the <a class="text-blue-500 hover:underline" href="/doc/html/index.html">index.html</a> file in the <code class="text-sm bg-gray-100 text-gray-800 p-1 rounded">doc</code> folder</li>
-                </ul>
-            </div>
-        
-            <div class="my-8 p-4 rounded-md bg-white shadow">
-                <h3 class="text-xl font-bold my-4">Generate GCOV test coverage</h3>
-                <p>GCOV is a test coverage program. It helps you determine how much of your source code is being tested by your test suite. It is a useful tool for finding untested code.</p>
-                <h3 class="text-lg font-bold my-2">📦 Prerequisites of gcov</h3>
-                <ul class="list-disc list-inside">
-                    <li><code class="text-sm bg-gray-100 text-gray-800 p-1 rounded">gcov</code>: <pre class="inline bg-gray-100 rounded"><code>sudo apt install gcov</code></pre></li>
-                    <li><code class="text-sm bg-gray-100 text-gray-800 p-1 rounded">lcov</code>: <pre class="inline bg-gray-100 rounded"><code>sudo apt install lcov</code></pre></li>
-                </ul>
-                <h3 class="text-lg font-bold my-2">🚀 How to run it</h3>
-                <ul class="list-disc list-inside">
-                    <li>Run <code class="text-sm bg-gray-100 text-gray-800 p-1 rounded">make gcov</code> to generate the coverage report</li>
-                    <li>To exit the coverage report, press <code class="text-sm bg-gray-100 text-gray-800 p-1 rounded">exit</code> two times (one for the shell and one for the coverage report)</li>
-                    <li>To view the coverage report, open the <a class="text-blue-500 hover:underline" href="/gcov/report/index.html">index.html</a> file in the <code class="text-sm bg-gray-100 text-gray-800 p-1 rounded">gcov/report/</code> folder or run <code class="text-sm bg-gray-100 text-gray-800 p-1 rounded">gcovr -r .</code></li>
-                    <li>Run <code class="text-sm bg-gray-100 text-gray-800 p-1 rounded">make clean-gcov</code> to clean the <code class="text-sm bg-gray-100 text-gray-800 p-1 rounded">gcov</code> folder</li>
-                </ul>
-            </div>
-        </div>
-        
-    </body>
+          .card {
+            @apply p-6 rounded-md border border-slate-200 hover:bg-slate-100 hover:border-slate-300 transition lg:max-w-72 flex flex-col gap-3 text-3xl text-slate-700 hover:text-slate-900;
+          }
+
+          .badge {
+            @apply inline p-1 px-2 rounded text-white w-fit text-sm;
+          }
+
+          h1 {
+            @apply text-4xl font-medium;
+          }
+
+          p {
+            @apply text-slate-600;
+          }
+        }
+      </style>
+</head>
+
+<body class="p-10 container mx-auto flex flex-col gap-12">
+    <div class="flex flex-col gap-4">
+        <img src="https://user-images.githubusercontent.com/62793491/208452652-71416c5c-8261-4501-a002-afc9e2cf0a0b.png"
+            class="w-52 rounded" />
+        <h1 class="mt-4">
+            Livl Shell documentation
+        </h1>
+        <p class="text-lg">
+            Livl Shell is an intermediate reimplementation of the bash shell in C language.
+        </p>
+    </div>
+
+
+    <div class="flex gap-2 max-lg:flex-col items-stretch">
+        <a href="https://livl-corporation.github.io/livl-shell/doc/html/" class="card">
+            <span class="badge bg-blue-500">DOXYGEN</span>
+            Visit the Doxygen documentation
+        </a>
+        <a href="https://livl-corporation.github.io/livl-shell/gcov/report/" class="card">
+            <span class="badge bg-green-500">GCOV</span>
+            Visit the GCOV coverage report
+        </a>
+    </div>
+
+    <a href="https://github.com/Livl-Corporation/livl-shell"
+        class="text-lg text-blue-600 hover:text-blue-500">GitHub</a>
+
+</body>
+
 </html>


### PR DESCRIPTION
## Github Page :
<img width="1287" alt="image" src="https://github.com/Livl-Corporation/livl-shell/assets/19238963/2f64a3ef-32d4-4034-952d-8f13c43157f0">

- Updated tailwindcss version
- I've removed the section about doc generation since it's already written in the README, i've replaced it with a link back to the github project. It allow us to have one only source for the doc generation tutorial.

## README : 
- i've decreased the title hierarchy by one to have only one H1 title that is the title of the project.
- added macos support

> note that a lot of links in the table of content doesn't works because of the emojis titles. You can use the [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) extension to spot them ;)

## typedef.h :
- i've added the corresponding operators next to the enum

