### PR TITLE
refactor(command): add input_string

### DIFF
--- a/include/command.h
+++ b/include/command.h
@@ -45,11 +45,4 @@ char **get_complete_command_array(Command *cmd);
  */
 void init_command(Command *cmd);
 
-/**
- * @brief Get the complete command (command + arguments) as a string
- * @param cmd: the command to get
- * @return the complete command as a string
- */
-char *get_complete_command(const Command *cmd);
-
 #endif // COMMAND_H

--- a/include/typedef.h
+++ b/include/typedef.h
@@ -96,6 +96,7 @@ typedef struct
     char *command;
     char **arguments;
     char **complete_command;
+    char *input_string;
     int num_arguments;
     Redirection redirection;
 } Command;

--- a/src/background_manager.c
+++ b/src/background_manager.c
@@ -3,38 +3,48 @@
 static BackgroundProcess background_processes[MAX_BACKGROUND_PROCESSES];
 static size_t num_background_processes = 0;
 
-void check_completed_background_processes() {
+void check_completed_background_processes()
+{
     size_t i = 0;
-    while (i < num_background_processes) {
+    while (i < num_background_processes)
+    {
         pid_t pid = background_processes[i].pid;
         int status;
         int result = waitpid(pid, &status, WNOHANG);
-        if (result == -1) {
+        if (result == -1)
+        {
             perror("waitpid");
-        } else if (result > 0) { // The process with PID 'pid' has completed
+        }
+        else if (result > 0)
+        { // The process with PID 'pid' has completed
             // Display the correct symbol based on the exit status
-            char symbol = i == num_background_processes-1 ? '+' : i == num_background_processes-2 ? '-' : ' ';
+            char symbol = i == num_background_processes - 1 ? '+' : i == num_background_processes - 2 ? '-'
+                                                                                                      : ' ';
             printf("[%d]%c  Done                    %s\n", background_processes[i].job_number, symbol, background_processes[i].command);
 
             // Free the memory for the completed process command
             free(background_processes[i].command);
 
             // Remove the completed process from the list
-            for (size_t j = i; j < num_background_processes - 1; ++j) {
+            for (size_t j = i; j < num_background_processes - 1; ++j)
+            {
                 background_processes[j] = background_processes[j + 1];
             }
             num_background_processes--;
-        } else {
+        }
+        else
+        {
             // Move to the next background process if the current one hasn't completed
             i++;
         }
     }
 }
 
-void add_background_process(pid_t pid, const Command *command) {
+void add_background_process(pid_t pid, const Command *command)
+{
     background_processes[num_background_processes].pid = pid;
     background_processes[num_background_processes].job_number = num_background_processes + 1;
-    background_processes[num_background_processes].command = get_complete_command(command);
+    background_processes[num_background_processes].command = command->input_string;
     printf("[%d] %d\n", background_processes[num_background_processes].job_number, pid);
     num_background_processes++;
 }

--- a/src/command.c
+++ b/src/command.c
@@ -40,6 +40,7 @@ Command evaluate_command(const char *input)
 
     // Get the complete command
     cmd.complete_command = get_complete_command_array(&cmd);
+    cmd.input_string = strdup(input);
 
     free(input_copy);
     return cmd;
@@ -58,33 +59,6 @@ void handle_quotes(char **token)
             (*token)++;        // Skip the initial quotation mark
         }
     }
-}
-
-char *get_complete_command(const Command *cmd)
-{
-    int total_length = strlen(cmd->command) + 1; // Include space for the null terminator
-
-    for (int i = 0; i < cmd->num_arguments; ++i)
-    {
-        total_length += strlen(cmd->arguments[i]) + 1; // Include space for the null terminator and space between arguments
-    }
-
-    char *complete_command = malloc(total_length);
-    if (complete_command == NULL)
-    {
-        perror("malloc");
-        exit(EXIT_FAILURE);
-    }
-
-    strcpy(complete_command, cmd->command);
-
-    for (int i = 0; i < cmd->num_arguments; ++i)
-    {
-        strcat(complete_command, " "); // Add space between arguments
-        strcat(complete_command, cmd->arguments[i]);
-    }
-
-    return complete_command;
 }
 
 char **get_complete_command_array(Command *cmd)
@@ -109,6 +83,7 @@ void init_command(Command *cmd)
     cmd->command = NULL;
     cmd->arguments = NULL;
     cmd->complete_command = NULL;
+    cmd->input_string = NULL;
     cmd->redirection.input_file = NULL;
     cmd->redirection.output_file = NULL;
     cmd->redirection.append_input = 0;
@@ -127,4 +102,5 @@ void free_command(Command *cmd)
     free(cmd->redirection.input_file);
     free(cmd->redirection.output_file);
     free(cmd->complete_command);
+    free(cmd->input_string);
 }


### PR DESCRIPTION
Instead of recreating the command as a string when needed, i directly store the original input in the command structure.